### PR TITLE
fix broken url and docstring

### DIFF
--- a/R/data.R
+++ b/R/data.R
@@ -26,8 +26,7 @@
 #' Franziska Paul, Yaara Arkin, Amir Giladi, DiegoAdhemar Jaitin, Ephraim Kenigsberg, Hadas KerenShaul, Deborah Winter, David Lara-Astiaso, Meital Gury, Assaf Weiner, Eyal David, Nadav Cohen,
 #' FeliciaKathrineBratt Lauridsen, Simon Haas, Andreas Schlitzer, Alexander Mildner, Florent Ginhoux,
 #' Steen Jung, Andreas Trumpp, BoTorben Porse, Amos Tanay, and Ido Amit. Transcriptional Heterogeneity and Lineage Commitment in Myeloid Progenitors. Cell, 163(7):1663–1677, 12 2015. ISSN 0092-
-#' 8674. doi: 10.1016/J.CELL.2015.11.013. URL https://www.sciencedirect.com/science/article/
-#' ii/S0092867415014932?via%3Dihub#app3.
+#' 8674. doi: 10.1016/J.CELL.2015.11.013. URL https://www.sciencedirect.com/science/article/pii/S0092867415014932
 #' @usage data(crv)
 "crv"
 
@@ -36,12 +35,11 @@
 #' This object contains the gene expression counts from the data described in
 #' Paul et al. (2015).
 #'
-#' #' @references
+#' @references
 #' Franziska Paul, Yaara Arkin, Amir Giladi, DiegoAdhemar Jaitin, Ephraim Kenigsberg, Hadas KerenShaul, Deborah Winter, David Lara-Astiaso, Meital Gury, Assaf Weiner, Eyal David, Nadav Cohen,
 #' FeliciaKathrineBratt Lauridsen, Simon Haas, Andreas Schlitzer, Alexander Mildner, Florent Ginhoux,
 #' Steen Jung, Andreas Trumpp, BoTorben Porse, Amos Tanay, and Ido Amit. Transcriptional Heterogeneity and Lineage Commitment in Myeloid Progenitors. Cell, 163(7):1663–1677, 12 2015. ISSN 0092-
-#' 8674. doi: 10.1016/J.CELL.2015.11.013. URL https://www.sciencedirect.com/science/article/
-#' ii/S0092867415014932?via%3Dihub#app3.
+#' 8674. doi: 10.1016/J.CELL.2015.11.013. URL https://www.sciencedirect.com/science/article/pii/S0092867415014932
 #' @usage data(countMatrix)
 "countMatrix"
 
@@ -51,11 +49,10 @@
 #' This object contains a vector that define the cell type for each cell in
 #' the data described in Paul et al. (2015).
 #'
-#' #' @references
+#' @references
 #' Franziska Paul, Yaara Arkin, Amir Giladi, DiegoAdhemar Jaitin, Ephraim Kenigsberg, Hadas KerenShaul, Deborah Winter, David Lara-Astiaso, Meital Gury, Assaf Weiner, Eyal David, Nadav Cohen,
 #' FeliciaKathrineBratt Lauridsen, Simon Haas, Andreas Schlitzer, Alexander Mildner, Florent Ginhoux,
 #' Steen Jung, Andreas Trumpp, BoTorben Porse, Amos Tanay, and Ido Amit. Transcriptional Heterogeneity and Lineage Commitment in Myeloid Progenitors. Cell, 163(7):1663–1677, 12 2015. ISSN 0092-
-#' 8674. doi: 10.1016/J.CELL.2015.11.013. URL https://www.sciencedirect.com/science/article/
-#' ii/S0092867415014932?via%3Dihub#app3.
+#' 8674. doi: 10.1016/J.CELL.2015.11.013. URL https://www.sciencedirect.com/science/article/pii/S0092867415014932
 #' @usage data(celltype)
 "celltype"


### PR DESCRIPTION
As shown in the following help page
![image](https://github.com/statOmics/tradeSeq/assets/13688320/cec69fc1-970f-40ff-84d6-b92cba7f9616)

- a redundant `#'` broke the docstring format for the reference section
- the link is broken, it is `pii` instead of `ii`, and the query string started with `?` appended in the URL should not be necessary.
